### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/episode-related.md
+++ b/.github/ISSUE_TEMPLATE/episode-related.md
@@ -1,0 +1,18 @@
+---
+name: Speaker Suggestion
+about: Propose a speaker for the podcast.
+title: "\U0001F3A7 Episode #X: SHORT_INFO"
+labels: podcast episode
+assignees: ''
+
+---
+
+# Episode
+- Number:
+- Time:
+
+Example: Say something about the episude ...
+
+# General Issue Information
+- `[WIP]` - Please add the **work in progress** prefix to your issue, if it is not completed yet.
+- `[RFC]` - Please add the **request for comments** prefix to your issue, if other should add comments.

--- a/.github/ISSUE_TEMPLATE/help-wanted.md
+++ b/.github/ISSUE_TEMPLATE/help-wanted.md
@@ -1,0 +1,14 @@
+---
+name: Help Wanted
+about: Ask the community for help.
+title: "\U0001F3E5 Help Wanted: SHORT_INFO"
+labels: help wanted
+assignees: ''
+
+---
+
+Describe the problem/project you are working on and ask for some guidance.
+
+# General Issue Information
+- `[WIP]` - Please add the **work in progress** prefix to your issue, if it is not completed yet.
+- `[RFC]` - Please add the **request for comments** prefix to your issue, if other should add comments.

--- a/.github/ISSUE_TEMPLATE/new-topic.md
+++ b/.github/ISSUE_TEMPLATE/new-topic.md
@@ -13,3 +13,7 @@ assignees: ''
 
 # Summary
 I want to talk about ...
+
+# General Issue Information
+- `[WIP]` - Please add the **work in progress** prefix to your issue, if it is not completed yet.
+- `[RFC]` - Please add the **request for comments** prefix to your issue, if other should add comments.

--- a/.github/ISSUE_TEMPLATE/new-topic.md
+++ b/.github/ISSUE_TEMPLATE/new-topic.md
@@ -1,0 +1,15 @@
+---
+name: New Topic
+about: Propose a topic for the podcast.
+title: "\U0001F4A1 Topic: YOUR_TOPIC"
+labels: new topic
+assignees: ''
+
+---
+
+# Keywords
+- Swift5
+- Result Type
+
+# Summary
+I want to talk about ...

--- a/.github/ISSUE_TEMPLATE/speaker-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/speaker-suggestion.md
@@ -1,0 +1,14 @@
+---
+name: Speaker Suggestion
+about: Propose a speaker for the podcast.
+title: "\U0001F3A4 Speaker: SPEAKER_NAME"
+labels: speaker suggestion
+assignees: ''
+
+---
+
+Example: Say something about the speaker ...
+
+# General Issue Information
+- `[WIP]` - Please add the **work in progress** prefix to your issue, if it is not completed yet.
+- `[RFC]` - Please add the **request for comments** prefix to your issue, if other should add comments.


### PR DESCRIPTION
As @neversitdull states in #10: it might be a good idea to add categories for new issues. [GitHub helps us](https://help.github.com/articles/creating-issue-templates-for-your-repository/) with this.

I just created one example for a "new topic". Some other templates might be:
- 🎤 Speaker/Guest suggestion
- 🎧 Podcast Episode #X related
- 🏥 help wanted

What do you think?
