### PR TITLE
Update structure of Audio/README

### DIFF
--- a/Audio/README.md
+++ b/Audio/README.md
@@ -2,8 +2,9 @@
 
 This page contains links to the original audio source files used to make the Swift Community Podcast. It’s recommended to use GarageBand for editing, even though it’s not the most sophisticated tool — since it’s [free from the App Store](https://itunes.apple.com/us/app/garageband/id682658836).
 
-Episodes:
-	- [Episode 1 (GarageBand file on Dropbox)](https://www.dropbox.com/s/lgn2um7wxg05bkh/SwiftCommunityPodcast-Episode1.zip?dl=0)
+## Episodes:
+- [Episode 1 (GarageBand file on Dropbox)](https://www.dropbox.com/s/lgn2um7wxg05bkh/SwiftCommunityPodcast-Episode1.zip?dl=0)
 
-Music:
-	- Possible intro song for the podcast (mp3): (https://www.dropbox.com/s/o1zfvcc1a57hzxh/podcastIntroSong.mp3?dl=0)
+## Music:
+- [Melody 1 (WAV file on Dropbox)](https://www.dropbox.com/s/o1zfvcc1a57hzxh/podcastIntroSong.mp3?dl=0)
+- [Melody 2](Melody%202.zip)


### PR DESCRIPTION
This PR simply adds the list of melody-files that are embedded in the repo, to the list of "Music" in the Audio-folder's README. It uses relative links for this.